### PR TITLE
fix: only process messages matching prefix and fix DETECT_FROM_ALL_ME…

### DIFF
--- a/.changeset/fix-message-listener-guard.md
+++ b/.changeset/fix-message-listener-guard.md
@@ -1,0 +1,5 @@
+---
+"stroycord": patch
+---
+
+Fix message listener processing unrelated messages when DETECT_FROM_ALL_MESSAGES is set. Parse env var as boolean properly (string "false" no longer treated as truthy). Only delete messages for recognized commands.

--- a/src/config/secrets.ts
+++ b/src/config/secrets.ts
@@ -12,7 +12,7 @@ const {
   DATABASE_NAME = 'stroycord',
   STROYCORD_LOGO = 'https://destroykeaum.alwaysdata.net/assets/other/stroybot_logo.png',
   LANGUAGE = 'en-US',
-  DETECT_FROM_ALL_MESSAGES = false,
+  DETECT_FROM_ALL_MESSAGES,
 } = process.env;
 
 if (!DISCORD_TOKEN) throw new Error('No token provided');
@@ -41,5 +41,5 @@ export const secrets = {
   DATABASE_NAME,
   STROYCORD_LOGO,
   LANGUAGE,
-  DETECT_FROM_ALL_MESSAGES,
+  DETECT_FROM_ALL_MESSAGES: DETECT_FROM_ALL_MESSAGES === 'true',
 };

--- a/src/listeners/messageListener.ts
+++ b/src/listeners/messageListener.ts
@@ -31,6 +31,7 @@ export default (client: Client): void => {
       splittedMessage = ['play', message.content];
     }
 
+    let handled = true;
     switch (command) {
       case 'play':
       case 'p':
@@ -64,15 +65,18 @@ export default (client: Client): void => {
         redoCommand(guild.guildId, textChannel, message.author, voiceChannel);
         break;
       default:
+        handled = false;
         message.channel.send({
           embeds: [unknownRequestEmbed()],
         });
         break;
     }
 
-    setTimeout(() => {
-      message.delete();
-    }, 1000);
+    if (handled) {
+      setTimeout(() => {
+        message.delete();
+      }, 1000);
+    }
   });
 
   client.on(Events.InteractionCreate, async (interaction) => {


### PR DESCRIPTION
…SSAGES boolean parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected `DETECT_FROM_ALL_MESSAGES` environment variable handling to properly parse boolean values
  * Restricted automatic message deletion to recognized commands only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->